### PR TITLE
fix: add missing migration 20260329080000 and update DB types for moo…

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1679,6 +1679,7 @@ export type Database = {
           id: string
           last_sync: string | null
           moodle_course_id: string
+          moodle_source: string
           name: string
           short_name: string | null
           start_date: string | null
@@ -1691,6 +1692,7 @@ export type Database = {
           id?: string
           last_sync?: string | null
           moodle_course_id: string
+          moodle_source?: string
           name: string
           short_name?: string | null
           start_date?: string | null
@@ -1703,6 +1705,7 @@ export type Database = {
           id?: string
           last_sync?: string | null
           moodle_course_id?: string
+          moodle_source?: string
           name?: string
           short_name?: string | null
           start_date?: string | null
@@ -2430,6 +2433,7 @@ export type Database = {
           id: string
           last_access: string | null
           mobile_phone: string | null
+          moodle_source: string
           moodle_user_id: string
           phone: string | null
           phone_number: string | null
@@ -2447,6 +2451,7 @@ export type Database = {
           id?: string
           last_access?: string | null
           mobile_phone?: string | null
+          moodle_source?: string
           moodle_user_id: string
           phone?: string | null
           phone_number?: string | null
@@ -2464,6 +2469,7 @@ export type Database = {
           id?: string
           last_access?: string | null
           mobile_phone?: string | null
+          moodle_source?: string
           moodle_user_id?: string
           phone?: string | null
           phone_number?: string | null

--- a/supabase/functions/_shared/db/generated.types.ts
+++ b/supabase/functions/_shared/db/generated.types.ts
@@ -1679,6 +1679,7 @@ export type Database = {
           id: string
           last_sync: string | null
           moodle_course_id: string
+          moodle_source: string
           name: string
           short_name: string | null
           start_date: string | null
@@ -1691,6 +1692,7 @@ export type Database = {
           id?: string
           last_sync?: string | null
           moodle_course_id: string
+          moodle_source?: string
           name: string
           short_name?: string | null
           start_date?: string | null
@@ -1703,6 +1705,7 @@ export type Database = {
           id?: string
           last_sync?: string | null
           moodle_course_id?: string
+          moodle_source?: string
           name?: string
           short_name?: string | null
           start_date?: string | null
@@ -2430,6 +2433,7 @@ export type Database = {
           id: string
           last_access: string | null
           mobile_phone: string | null
+          moodle_source: string
           moodle_user_id: string
           phone: string | null
           phone_number: string | null
@@ -2447,6 +2451,7 @@ export type Database = {
           id?: string
           last_access?: string | null
           mobile_phone?: string | null
+          moodle_source?: string
           moodle_user_id: string
           phone?: string | null
           phone_number?: string | null
@@ -2464,6 +2469,7 @@ export type Database = {
           id?: string
           last_access?: string | null
           mobile_phone?: string | null
+          moodle_source?: string
           moodle_user_id?: string
           phone?: string | null
           phone_number?: string | null

--- a/supabase/migrations/20260329080000_add_moodle_source_to_courses_and_students.sql
+++ b/supabase/migrations/20260329080000_add_moodle_source_to_courses_and_students.sql
@@ -1,0 +1,9 @@
+-- Adiciona coluna moodle_source em courses e students para suporte a múltiplas
+-- origens de sincronização Moodle (ex: 'goias', 'nacional').
+-- O valor padrão 'goias' garante retrocompatibilidade com registros existentes.
+
+ALTER TABLE public.courses
+  ADD COLUMN IF NOT EXISTS moodle_source TEXT NOT NULL DEFAULT 'goias';
+
+ALTER TABLE public.students
+  ADD COLUMN IF NOT EXISTS moodle_source TEXT NOT NULL DEFAULT 'goias';


### PR DESCRIPTION
…dle_source column

The remote Supabase database had migration 20260329080000 applied, but the migration file was missing from the git repository. This caused CI/CD deployments to fail with a migration version mismatch error.

Changes:
- Added supabase/migrations/20260329080000_add_moodle_source_to_courses_and_students.sql
- Updated src/integrations/supabase/types.ts to include moodle_source column
- Updated supabase/functions/_shared/db/generated.types.ts to include moodle_source column

The moodle_source column enables multi-source Moodle synchronization support (e.g., 'goias', 'nacional') with backward compatibility via default value 'goias'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)